### PR TITLE
Add a parameter to change default namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ wmic = wmi.WmiClientWrapper(
 )
 
 output = wmic.query("SELECT * FROM Win32_Processor")
+
+#get FibrePort Info
+wmic = wmi.WmiClientWrapper(
+    username="Administrator",
+    password="password",
+    host="192.168.1.1",
+    namespace='//./root/WMI'
+)
+output = wmic.query('Select * FROM MSFC_FibrePortNPIVAttributes')
+
 ```
 
 ## testing

--- a/wmi_client_wrapper/wrapper.py
+++ b/wmi_client_wrapper/wrapper.py
@@ -19,7 +19,7 @@ class WmiClientWrapper(object):
     it directly to end-users.
     """
 
-    def __init__(self, username="Administrator", password=None, host=None, delimiter="\01"):
+    def __init__(self, username="Administrator", password=None, host=None, namespace='//./root/cimv2', delimiter="\01"):
         assert username
         assert password
         assert host # assume host is up
@@ -30,7 +30,8 @@ class WmiClientWrapper(object):
         self.host = host
 
         self.delimiter = delimiter
-
+        self.namespace = namespace
+        
     def _make_credential_args(self):
         """
         Makes credentials that get passed to wmic. This assembles a list of
@@ -51,7 +52,10 @@ class WmiClientWrapper(object):
         hostaddr = "//{host}".format(host=self.host)
 
         arguments.append(hostaddr)
-
+        # the format for namespace
+        space= "--namespace={namespace}".format(namespace=self.namespace)
+        
+        arguments.append(space)
         return arguments
 
     def _setup_params(self):


### PR DESCRIPTION
    the class i want to use is in another namespace , for example, the HBA card and its' wwn could be founded in class MSFC_FibrePortNPIVAttributes, but this class is in 'root/WMI'.
so i added a parameter to do that.  :))