### PR TITLE
Added Python3 support (reliant on futures module)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ pip install wmi-client-wrapper
 ## usage
 
 ```
-import wmi_client_wrapper as wmi
+from wmi_client_wrapper import WmiClientWrapper
 
-wmic = wmi.WmiClientWrapper(
+wmic = WmiClientWrapper(
     username="Administrator",
     password="password",
     host="192.168.1.149",
@@ -23,7 +23,7 @@ wmic = wmi.WmiClientWrapper(
 
 output = wmic.query("SELECT * FROM Win32_Processor")
 
-#get FibrePort Info
+# get FibrePort Info
 wmic = wmi.WmiClientWrapper(
     username="Administrator",
     password="password",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 # because testing
-mock
+mock==2.0.0
 
 # because pass-through
-sh
+sh==1.12.14
+
+# to assist with Python2/3 compatibility
+future==0.16.0

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,14 @@ if sys.argv[-1] == 'publish':
 # There's some intersection with requirements.txt but pypi can't handle git
 # dependencies. So it's better to just manually list dependencies again.
 requires = [
-    "mock",
-    "sh",
+    'mock==2.0.0',
+    'sh==1.12.14',
+    'future==0.16.0',
 ]
 
 setup(
     name="wmi-client-wrapper",
-    version="0.0.12",
+    version="0.0.13",
     description="Linux-only wrapper around wmi-client for WMI (Windows)",
     long_description=open("README.md", "r").read(),
     license="BSD",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,11 +1,19 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import os
 import unittest
+
 import mock
+from future import standard_library
 
 import wmi_client_wrapper as wmi
 
-import os
+standard_library.install_aliases()
+
 
 datapath = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data/")
+
 
 class TestCases(unittest.TestCase):
     def test_object_creation_raises_without_username(self):
@@ -81,6 +89,7 @@ class TestCases(unittest.TestCase):
 
             self.assertNotIn({"AcceptPause": "CLASS: Win32_Service"}, result)
 
+
 class DictionaryWalkingTestCases(unittest.TestCase):
     def test_basic_dictionary_output(self):
         incoming = {}
@@ -147,6 +156,7 @@ class DictionaryWalkingTestCases(unittest.TestCase):
         self.assertIn("beep", output[0])
         self.assertEqual(output[0]["beep"], None)
 
+
 class MoreTestCases(unittest.TestCase):
     def setUp(self):
         self.wmic = wmi.WmiClientWrapper(
@@ -162,12 +172,13 @@ class MoreTestCases(unittest.TestCase):
         args = self.wmic._make_credential_args()
 
     @mock.patch("wmi_client_wrapper.wrapper.WmiClientWrapper._parse_wmic_output")
-    @mock.patch("wmi_client_wrapper.wrapper.sh.wmic")
-    def test_query_calls(self, mock_sh_wmic, mock_parser):
+    @mock.patch("wmi_client_wrapper.wrapper.sh")
+    def test_query_calls(self, mock_sh, mock_parser):
         self.wmic.query("")
 
-        self.assertTrue(mock_sh_wmic.called)
+        self.assertTrue(mock_sh.wmic.called)
         self.assertTrue(mock_parser.called)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wmi_client_wrapper/__init__.py
+++ b/wmi_client_wrapper/__init__.py
@@ -1,1 +1,4 @@
-from wrapper import WmiClientWrapper
+from .wrapper import WmiClientWrapper
+
+# avoid unused import warning
+_ = WmiClientWrapper

--- a/wmi_client_wrapper/wrapper.py
+++ b/wmi_client_wrapper/wrapper.py
@@ -4,10 +4,24 @@ Houses the wrapper for wmi-client.
 There are a handful of injection vulnerabilities in this, so don't expose it
 directly to end-users.
 """
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import csv
+from builtins import object, str
+from io import StringIO
+from sys import version_info
+
 import sh
-from StringIO import StringIO
+from future import standard_library
+
+standard_library.install_aliases()
+
+
+# because standard_library.install_aliases() replaces str with newstr which upsets csv module
+if version_info[0] < 3:
+    from past.types.oldstr import oldstr as str
+
 
 class WmiClientWrapper(object):
     """
@@ -22,7 +36,7 @@ class WmiClientWrapper(object):
     def __init__(self, username="Administrator", password=None, host=None, namespace='//./root/cimv2', delimiter="\01"):
         assert username
         assert password
-        assert host # assume host is up
+        assert host  # assume host is up
 
         # store the credentials for later
         self.username = username
@@ -31,7 +45,7 @@ class WmiClientWrapper(object):
 
         self.delimiter = delimiter
         self.namespace = namespace
-        
+
     def _make_credential_args(self):
         """
         Makes credentials that get passed to wmic. This assembles a list of
@@ -53,8 +67,8 @@ class WmiClientWrapper(object):
 
         arguments.append(hostaddr)
         # the format for namespace
-        space= "--namespace={namespace}".format(namespace=self.namespace)
-        
+        space = "--namespace={namespace}".format(namespace=self.namespace)
+
         arguments.append(space)
         return arguments
 
@@ -139,7 +153,7 @@ class WmiClientWrapper(object):
 
             strio = StringIO(section)
 
-            moredata = list(csv.DictReader(strio, delimiter=delimiter))
+            moredata = list(csv.DictReader(strio, delimiter=str(delimiter)))
             items.extend(moredata)
 
         # walk the dictionaries!
@@ -171,7 +185,7 @@ class WmiClientWrapper(object):
         elif isinstance(incoming, dict):
             output = dict()
 
-            for (key, value) in incoming.items():
+            for (key, value) in list(incoming.items()):
                 if value == "(null)":
                     output[key] = None
                 elif value == "True":


### PR DESCRIPTION
This PR refers to the following issue:

[Consider adding Python3 support](https://github.com/kanzure/python-wmi-client-wrapper/issues/12)

It is to add Python3 support (while retaining Python2 support).

It relies on the "future" Python module and all unit tests pass under Python2.7, Python3.6, PyPy 5.10 and PyPy3 5.10.1.

Manual end-to-end testing against an actual Windows server seems fine under both Python2.7 and Python3.5 in an Ubuntu Docker container.